### PR TITLE
Remove annoying bottom space and added transitions

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ body {
     justify-content: center;
     font-family: sans-serif;
 
-    height: 100vh;
+    /* height: 100vh; somehow, this line create an annoying bottom space*/
     background-image: linear-gradient(to right bottom, #051b37, #00486d, #007c9e, #00b3c3, #12ebd8);
 }
 
@@ -22,9 +22,8 @@ body {
     justify-content: center;
     flex-wrap: wrap;
 
-    margin: 20px;
     width: 100%;
-    height: 800px;
+    height: 100vh;
     border: 1px solid;
     border-radius: 10px;
     border: none;
@@ -56,7 +55,7 @@ flex-direction: column;
 
     background-color: whitesmoke;
     width: 60%;
-    height: 100%;
+    height: 100vh;
     border-radius: 0 10px 10px 0;
 }
 
@@ -100,6 +99,7 @@ flex-direction: column;
     padding: 12px;
     border-radius: 7px;
     cursor: pointer;
+    transition: all 100ms ease-ins;
 }
 
 .socials .facebook-btn span{
@@ -109,6 +109,7 @@ flex-direction: column;
 
 .socials .facebook-btn:hover {
     background-color: rgb(9, 97, 170);
+    transition: all 100ms ease-out;
 }
 
 .socials .google-btn {
@@ -117,6 +118,7 @@ flex-direction: column;
     padding: 12px;
     border-radius: 7px;
     cursor: pointer;
+    transition: all 100ms ease-in;
 }
 
 .socials .google-btn span{
@@ -126,13 +128,14 @@ flex-direction: column;
 .socials .google-btn:hover {
     background-color: rgb(185, 185, 185);
     color: white;
-    border: 1px solid rgb(185, 185, 185);;
+    border: 1px solid rgb(185, 185, 185);
+    transition: all 100ms ease-out;
 }
 
 .fa-google {
     background: 
       linear-gradient(to bottom left,transparent 49%,#fbbc05 50%) 0 25%/48% 40%,
-      linear-gradient(to top    left,transparent 49%,#fbbc05 50%) 0 75%/48% 40%,
+      linear-gradient(to top left,transparent 49%,#fbbc05 50%) 0 75%/48% 40%,
     
       linear-gradient(-40deg ,transparent 53%,#ea4335 54%),
       linear-gradient( 45deg ,transparent 46%,#4285f4 48%),


### PR DESCRIPTION
- With some reason, usign `%` instead of `vh` create a useless space at the bottom of the page, this commit get rid of it completely
- Added simple fading animation/transition at `facebook-btn` and `google-btn`

TODO : I'll prepare some code refactor for responsive design later